### PR TITLE
Fixes #15 Don't retain focus on the target element after the label is clicked

### DIFF
--- a/iron-label.html
+++ b/iron-label.html
@@ -121,6 +121,7 @@ All taps on the `iron-label` will be forwarded to the "target" element.
         }
         this._forElement.focus();
         this._forElement.click();
+        this._forElement.blur();
       },
 
       _applyLabelledBy: function() {


### PR DESCRIPTION
Call blur after click on the forElement to unfocus
