### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/iron-label.js
+++ b/iron-label.js
@@ -61,6 +61,7 @@ All taps on the `iron-label` will be forwarded to the "target" element.
 */
 export const IronLabel = Polymer({
   is: 'iron-label',
+  _template: null,
 
   listeners: {'tap': '_tapHandler'},
 


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336